### PR TITLE
Streamline dev deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries for programs and plugins
 registration
+dev-kubeconfig
 *.exe
 *.dll
 *.so

--- a/README.md
+++ b/README.md
@@ -24,24 +24,14 @@ You can reach the maintainers of this project at:
 Check the [Development Doc](docs/development.md) for how to contribute to the repo.
 
 ## How to Deploy
+
 ### Deploy Hub
+
 1. Run `make deploy-hub`
 
 ### Deploy Spoke
-1. Create a bootstrap kubeconfig secret in the namespace of `open-cluster-management`.
-Ensure the server field in kubeconfig is accesible from cluster. 
 
-    In a kind environment where hub and spoke component is deployed in one cluster, default kubernetes cluster ip can be used.
-
-    ```sh
-    cp ~/.kube/config /<path>/kubeconfig
-    clusterIP=$(kubectl get svc kubernetes -n default -o jsonpath="{.spec.clusterIP}")
-    kubectl config set clusters.kind-kind.server https://$clusterIP --kubeconfig /<path>/kubeconfig
-    ```
-    Then run the following command
-    ```sh
-    kubectl create secret generic bootstrap-secret --from-file=kubeconfig=/<path>/kubeconfig -n open-cluster-management
-    ```
+1. Run `make bootstrap-secret`
 2. Run `make deploy-spoke`
 
 ## Security Response


### PR DESCRIPTION
Makes it possible to deploy hub and spoke fully through `make`, adds a `test-e2e` target we can use to experiment with CI.