### PR TITLE
Add a name field selector to spoke cluster informer factory to solve agent cannot list spokeclusters problem

### DIFF
--- a/pkg/spoke/spokeagent.go
+++ b/pkg/spoke/spokeagent.go
@@ -184,7 +184,7 @@ func (o *SpokeAgentOptions) RunSpokeAgent(ctx context.Context, controllerContext
 	}
 
 	hubKubeInformerFactory := informers.NewSharedInformerFactory(hubKubeClient, 10*time.Minute)
-	// create an informer factory with cluster name field selector because we just need to handle the current spoke cluster
+	// create a cluster informer factory with name field selector because we just need to handle the current spoke cluster
 	hubClusterInformerFactory := clusterv1informers.NewSharedInformerFactoryWithOptions(
 		hubClusterClient,
 		10*time.Minute,


### PR DESCRIPTION
After hub cluster admin accept the spoke cluster, there will be errors in agent

```
E0511 06:45:49.129854       1 reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.2/tools/cache/reflector.go:125: Failed to list *v1.SpokeCluster: spokeclusters.cluster.open-cluster-management.io is forbidden: User "system:open-cluster-management:spokecluster1:ghnl5" cannot list resource "spokeclusters" in API group "cluster.open-cluster-management.io" at the cluster scope
```
the root cause is `resourceNames` cannot be apply with list/watch rule