### PR TITLE
Allow spoke work agent to update manifestworks

### DIFF
--- a/pkg/hub/spokecluster/bindata/bindata.go
+++ b/pkg/hub/spokecluster/bindata/bindata.go
@@ -148,10 +148,10 @@ rules:
 - apiGroups: ["", "events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
-# Allow spoke work agent to get/list/watch manifestworks
+# Allow spoke work agent to get/list/watch/update manifestworks
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "update"]
 # Allow spoke work agent to update the status of manifestwork
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks/status"]

--- a/pkg/hub/spokecluster/manifests/spokecluster-work-role.yaml
+++ b/pkg/hub/spokecluster/manifests/spokecluster-work-role.yaml
@@ -8,10 +8,10 @@ rules:
 - apiGroups: ["", "events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
-# Allow spoke work agent to get/list/watch manifestworks
+# Allow spoke work agent to get/list/watch/update manifestworks
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "update"]
 # Allow spoke work agent to update the status of manifestwork
 - apiGroups: ["work.open-cluster-management.io"]
   resources: ["manifestworks/status"]


### PR DESCRIPTION
With `update` permission, spoke work agent is able to add/remove finalizer to/from manifestworks.