### PR TITLE
RBAC escalation for granting per-cluster RBAC-rules to managedclusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ e2e.test
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 _output/
+.idea/

--- a/deploy/hub/hub_controller_clusterrole.yaml
+++ b/deploy/hub/hub_controller_clusterrole.yaml
@@ -10,10 +10,14 @@ rules:
 - apiGroups: ["certificates.k8s.io"]
   resources: ["certificatesigningrequests/status"]
   verbs: ["update"]
-# Allow hub to get/list/watch/create/delete namespace and service account
+# Allow hub to get/list/watch/create/delete configmap, namespace and service account
 - apiGroups: [""]
   resources: ["namespaces", "serviceaccounts", "configmaps", "events"]
   verbs: ["get", "list", "watch", "create", "delete", "update"]
+# Allow hub to record events
+- apiGroups: ["", "events.k8s.io"]
+  resources: ["events"]
+  verbs: ["get", "create", "delete", "update"]
 # Allow hub to manage clusterrole/clusterrolebinding/role/rolebinding
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]

--- a/deploy/hub/managedcluster_escalation_clusterrole.yaml
+++ b/deploy/hub/managedcluster_escalation_clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:hub:escalation
+rules:
+# Allow work agent to get/list/watch/update manifestworks
+- apiGroups: ["work.open-cluster-management.io"]
+  resources: ["manifestworks"]
+  verbs: ["get", "list", "watch", "update"]
+# Allow work agent to update the status of manifestwork
+- apiGroups: ["work.open-cluster-management.io"]
+  resources: ["manifestworks/status"]
+  verbs: ["patch", "update"]

--- a/deploy/hub/managedcluster_escalation_clusterrolebinding.yaml
+++ b/deploy/hub/managedcluster_escalation_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: open-cluster-management:hub:escalation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: open-cluster-management:hub:escalation
+subjects:
+  - kind: ServiceAccount
+    name: hub-sa
+    namespace: open-cluster-management


### PR DESCRIPTION
the managedcluster-controller will be creating per-cluster role/rolebinding to the corresponding namespace which requires the RBAC permission escalation. this pull adds sufficient RBAC permission to the default manifests so that the automatic creation will work.