### PR TITLE
Defining a common user-group to match all spoke-clusters

### DIFF
--- a/pkg/hub/csr/controller.go
+++ b/pkg/hub/csr/controller.go
@@ -160,8 +160,8 @@ func isSpokeClusterClientCertRenewal(csr *certificatesv1beta1.CertificateSigning
 	}
 
 	requestingOrgs := sets.NewString(x509cr.Subject.Organization...)
-	if requestingOrgs.Has(user.SpokeClustersGroup) { // optional common group for backward-compatibility
-		requestingOrgs.Delete(user.SpokeClustersGroup)
+	if requestingOrgs.Has(user.ManagedClustersGroup) { // optional common group for backward-compatibility
+		requestingOrgs.Delete(user.ManagedClustersGroup)
 	}
 	if requestingOrgs.Len() != 1 {
 		return false

--- a/pkg/hub/user/doc.go
+++ b/pkg/hub/user/doc.go
@@ -1,0 +1,2 @@
+// Package user contains common definition works for kubernetes certificates
+package user

--- a/pkg/hub/user/identity.go
+++ b/pkg/hub/user/identity.go
@@ -1,0 +1,8 @@
+package user
+
+const (
+	// SubjectPrefix is a prefix for marking open-cluster-management users
+	SubjectPrefix = "system:open-cluster-management:"
+	// SpokeClustersGroup is a common group for all spoke clusters
+	SpokeClustersGroup = SubjectPrefix + "spoke-clusters"
+)

--- a/pkg/hub/user/identity.go
+++ b/pkg/hub/user/identity.go
@@ -3,6 +3,6 @@ package user
 const (
 	// SubjectPrefix is a prefix for marking open-cluster-management users
 	SubjectPrefix = "system:open-cluster-management:"
-	// SpokeClustersGroup is a common group for all spoke clusters
-	SpokeClustersGroup = SubjectPrefix + "spoke-clusters"
+	// ManagedClustersGroup is a common group for all spoke clusters
+	ManagedClustersGroup = SubjectPrefix + "managed-clusters"
 )

--- a/pkg/spoke/hubclientcert/certificate.go
+++ b/pkg/spoke/hubclientcert/certificate.go
@@ -12,6 +12,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
+
+	"github.com/open-cluster-management/registration/pkg/hub/user"
 )
 
 // HasValidKubeconfig checks if there exists a valid kubeconfig in the given secret
@@ -185,10 +187,10 @@ func GetClusterAgentNamesFromCertificate(certData []byte) (clusterName, agentNam
 	}
 
 	for _, cert := range certs {
-		if ok := strings.HasPrefix(cert.Subject.CommonName, subjectPrefix); !ok {
+		if ok := strings.HasPrefix(cert.Subject.CommonName, user.SubjectPrefix); !ok {
 			continue
 		}
-		names := strings.Split(strings.TrimPrefix(cert.Subject.CommonName, subjectPrefix), ":")
+		names := strings.Split(strings.TrimPrefix(cert.Subject.CommonName, user.SubjectPrefix), ":")
 		if len(names) != 2 {
 			continue
 		}

--- a/pkg/spoke/hubclientcert/controller.go
+++ b/pkg/spoke/hubclientcert/controller.go
@@ -287,7 +287,7 @@ func (c *ClientCertForHubController) createCSR() (string, error) {
 	subject := &pkix.Name{
 		Organization: []string{
 			fmt.Sprintf("%s%s", user.SubjectPrefix, c.clusterName),
-			user.SpokeClustersGroup,
+			user.ManagedClustersGroup,
 		},
 		CommonName: fmt.Sprintf("%s%s:%s", user.SubjectPrefix, c.clusterName, c.agentName),
 	}

--- a/pkg/spoke/hubclientcert/controller.go
+++ b/pkg/spoke/hubclientcert/controller.go
@@ -28,6 +28,8 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
 	"k8s.io/klog/v2"
+
+	"github.com/open-cluster-management/registration/pkg/hub/user"
 )
 
 const (
@@ -38,7 +40,6 @@ const (
 	// TLSCertFile is the name of the tls cert file in kubeconfigSecret
 	TLSCertFile = "tls.crt"
 
-	subjectPrefix         = "system:open-cluster-management:"
 	clusterNameAnnotation = "open-cluster-management.io/cluster-name"
 	ClusterNameFile       = "cluster-name"
 	AgentNameFile         = "agent-name"
@@ -181,7 +182,7 @@ func (c *ClientCertForHubController) sync(ctx context.Context, syncCtx factory.S
 	// create a csr to request new client certificate if
 	// a. there is no valid client certificate issued for the current cluster/agent
 	// b. client certificate exists and has less than 20% of its life remaining
-	if hasValidKubeconfig(secret, fmt.Sprintf("%s%s:%s", subjectPrefix, c.clusterName, c.agentName)) {
+	if hasValidKubeconfig(secret, fmt.Sprintf("%s%s:%s", user.SubjectPrefix, c.clusterName, c.agentName)) {
 		notBefore, notAfter, err := getCertValidityPeriod(secret)
 		if err != nil {
 			return err
@@ -284,8 +285,11 @@ func (c *ClientCertForHubController) syncCSR(secret *corev1.Secret) (map[string]
 
 func (c *ClientCertForHubController) createCSR() (string, error) {
 	subject := &pkix.Name{
-		Organization: []string{fmt.Sprintf("%s%s", subjectPrefix, c.clusterName)},
-		CommonName:   fmt.Sprintf("%s%s:%s", subjectPrefix, c.clusterName, c.agentName),
+		Organization: []string{
+			fmt.Sprintf("%s%s", user.SubjectPrefix, c.clusterName),
+			user.SpokeClustersGroup,
+		},
+		CommonName: fmt.Sprintf("%s%s:%s", user.SubjectPrefix, c.clusterName, c.agentName),
 	}
 
 	privateKey, err := keyutil.ParsePrivateKeyPEM(c.keyData)

--- a/pkg/spoke/hubclientcert/controller_test.go
+++ b/pkg/spoke/hubclientcert/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
+	"github.com/open-cluster-management/registration/pkg/hub/user"
 
 	certificates "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,7 +27,7 @@ const (
 	testCSRName    = "testcsr"
 )
 
-var commonName = fmt.Sprintf("%s%s:%s", subjectPrefix, testinghelpers.TestManagedClusterName, testAgentName)
+var commonName = fmt.Sprintf("%s%s:%s", user.SubjectPrefix, testinghelpers.TestManagedClusterName, testAgentName)
 
 func TestSync(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
so that we can grant extra common RBAC permissions to the CSR-generated certificates mounted by the spoke-agent

@qiujian16 