### PR TITLE
Fix issues in unit-test and e2e-test

### DIFF
--- a/test/e2e/loopback_test.go
+++ b/test/e2e/loopback_test.go
@@ -307,6 +307,9 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		err = wait.Poll(1*time.Second, 90*time.Second, func() (bool, error) {
 			var err error
 			managedCluster, err = managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
### Unit-test
function `getCertValidityPeriod` will return `NotBefore` and `NotAfter` with minimal time scope. 
In this test, first_cert and second_cert is like below:
```
first cert       : | time.Now() --------- 10 secs ------- NotAfter | 
second cert :            | time.Now() -- 5 secs -- NotAfter | 
```
Which means **normally** we get a cert with `NotBefore` and `NotAfter` equals to second cert.

But if CPU resource is limited, and all unit-test cases run concurrently, second cert may created after first cert created by several seconds, which like below:
```
first cert       : | time.Now() --------- 10 secs ------- NotAfter | 
second cert :                                                 | time.Now() -- 5 secs -- NotAfter | 
```

So we need to do comparison at first. 

### e2e-test
` NotFound` is a special case and should not return err.

Signed-off-by: xuezhaojun <zxue@redhat.com>