### PR TITLE
test: address flaky e2e test

### DIFF
--- a/test/e2e/loopback_test.go
+++ b/test/e2e/loopback_test.go
@@ -52,7 +52,14 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		if !errors.IsNotFound(err) {
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		}
-		_, err = hubDynamicClient.Resource(gvr).Create(context.TODO(), claimCrd, metav1.CreateOptions{})
+		err = wait.Poll(1*time.Second, 5*time.Second, func() (done bool, err error) {
+			_, err = hubDynamicClient.Resource(gvr).Create(context.TODO(), claimCrd, metav1.CreateOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			return true, nil
+		})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// create ClusterClaim cr


### PR DESCRIPTION
When exec the e2e tests on an environment a claim crd exists,
the lookback test may be failed by 'object is being deleted:
customresourcedefinitions.apiextensions.k8s.io
"clusterclaims.cluster.open-cluster-management.io" already exists'

Signed-off-by: zhujian7 <zjfqxa@gmail.com>