### PR TITLE
Report all res information to managedcluster status like cpu and memory

### DIFF
--- a/test/e2e/loopback_test.go
+++ b/test/e2e/loopback_test.go
@@ -425,6 +425,34 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
+		// make sure the cpu and memory are still in the status, for compatibility
+		ginkgo.By("Make sure cpu and memory exist in status")
+		err = wait.Poll(1*time.Second, 30*time.Second, func() (bool, error) {
+			managedCluster, err := managedClusters.Get(context.TODO(), clusterName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			if _, exist := managedCluster.Status.Allocatable[clusterv1.ResourceCPU]; !exist {
+				return false, fmt.Errorf("Resource %v doesn't exist in Allocatable", clusterv1.ResourceCPU)
+			}
+
+			if _, exist := managedCluster.Status.Allocatable[clusterv1.ResourceMemory]; !exist {
+				return false, fmt.Errorf("Resource %v doesn't exist in Allocatable", clusterv1.ResourceMemory)
+			}
+
+			if _, exist := managedCluster.Status.Capacity[clusterv1.ResourceCPU]; !exist {
+				return false, fmt.Errorf("Resource %v doesn't exist in Capacity", clusterv1.ResourceCPU)
+			}
+
+			if _, exist := managedCluster.Status.Capacity[clusterv1.ResourceMemory]; !exist {
+				return false, fmt.Errorf("Resource %v doesn't exist in Capacity", clusterv1.ResourceMemory)
+			}
+
+			return true, nil
+		})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
 		ginkgo.By("Make sure ClusterClaims are synced")
 		clusterClaims := []clusterv1.ManagedClusterClaim{
 			{


### PR DESCRIPTION
Signed-off-by: suigh <suigh@cn.ibm.com>

This change is used to report the GPU information to hub cluster, the status in the managedcluster will be updated. We will use this GPU information to get placement decision in the future.

`nvidia.com/gpu` is used here for GPU information because:
1: it is used by nvidia and k8s
2: if we support other GPUs (like AMD gpu) later, we needn't change the current name that only for nvidia gpu only, no compatibility issue.

The output of `kc describe managedclusters` is updated as following, `nvidia.com/gpu` is displayed:
```
Name:         cluster2
 ......
Spec:
  Hub Accepts Client:      true
  Lease Duration Seconds:  60
  ......
Status:
  Allocatable:
    Cpu:             64
    Memory:          256168Mi
    nvidia.com/gpu:  1
  Capacity:
    Cpu:             64
    Memory:          256468Mi
    nvidia.com/gpu:  1
  Conditions:
```

BTW: Thanks very much for Jian (@zhujian7), without his help, I cannot build the test env at all.