### PR TITLE
deploy control plane and agent in two clusters

### DIFF
--- a/deploy/hub/hub_controller_clusterrole_binding.yaml
+++ b/deploy/hub/hub_controller_clusterrole_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: hub-sa
-    namespace: open-cluster-management
+    namespace: open-cluster-management-hub

--- a/deploy/hub/kustomization.yaml
+++ b/deploy/hub/kustomization.yaml
@@ -1,6 +1,6 @@
 
 # Adds namespace to all resources.
-namespace: open-cluster-management
+namespace: open-cluster-management-hub
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/deploy/hub/managedcluster_escalation_clusterrolebinding.yaml
+++ b/deploy/hub/managedcluster_escalation_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: hub-sa
-    namespace: open-cluster-management
+    namespace: open-cluster-management-hub

--- a/deploy/hub/namespace.yaml
+++ b/deploy/hub/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: open-cluster-management
+  name: open-cluster-management-hub

--- a/deploy/spoke/clusterrole_binding.yaml
+++ b/deploy/spoke/clusterrole_binding.yaml
@@ -10,4 +10,3 @@ subjects:
   - kind: ServiceAccount
     name: spoke-agent-sa
     namespace: open-cluster-management-agent
-  

--- a/deploy/spoke/clusterrole_binding.yaml
+++ b/deploy/spoke/clusterrole_binding.yaml
@@ -9,5 +9,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spoke-agent-sa
-    namespace: open-cluster-management
+    namespace: open-cluster-management-agent
   

--- a/deploy/spoke/kustomization.yaml
+++ b/deploy/spoke/kustomization.yaml
@@ -1,6 +1,6 @@
 
 # Adds namespace to all resources.
-namespace: open-cluster-management
+namespace: open-cluster-management-agent
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/deploy/spoke/namespace.yaml
+++ b/deploy/spoke/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: open-cluster-management
+  name: open-cluster-management-agent

--- a/deploy/spoke/role.yaml
+++ b/deploy/spoke/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: open-cluster-management:registration-agent
-  namespace: open-cluster-management
+  namespace: open-cluster-management-agent
 rules:
 - apiGroups: [""]
   resources: ["configmaps", "secrets"]

--- a/deploy/spoke/role_binding.yaml
+++ b/deploy/spoke/role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: open-cluster-management:registration-agent
-  namespace: open-cluster-management
+  namespace: open-cluster-management-agent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spoke-agent-sa
-    namespace: open-cluster-management
+    namespace: open-cluster-management-agent

--- a/deploy/webhook/apiservice.yaml
+++ b/deploy/webhook/apiservice.yaml
@@ -7,7 +7,7 @@ spec:
   version: v1
   service:
     name: managedcluster-admission
-    namespace: open-cluster-management
+    namespace: open-cluster-management-hub
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 10000
   versionPriority: 20

--- a/deploy/webhook/clusterrole_binding.yaml
+++ b/deploy/webhook/clusterrole_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: managedcluster-admission-sa
-    namespace: open-cluster-management
+    namespace: open-cluster-management-hub

--- a/deploy/webhook/kustomization.yaml
+++ b/deploy/webhook/kustomization.yaml
@@ -1,6 +1,6 @@
 
 # Adds namespace to all resources.
-namespace: open-cluster-management
+namespace: open-cluster-management-hub
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/pkg/spoke/spokeagent.go
+++ b/pkg/spoke/spokeagent.go
@@ -42,7 +42,7 @@ const (
 	// spokeAgentNameLength is the length of the spoke agent name which is generated automatically
 	spokeAgentNameLength = 5
 	// defaultSpokeComponentNamespace is the default namespace in which the spoke agent is deployed
-	defaultSpokeComponentNamespace = "open-cluster-management"
+	defaultSpokeComponentNamespace = "open-cluster-management-agent"
 )
 
 // AddOnLeaseControllerSyncInterval is exposed so that integration tests can crank up the constroller sync speed.

--- a/test/e2e/addon_lease_test.go
+++ b/test/e2e/addon_lease_test.go
@@ -390,8 +390,8 @@ func createManagedCluster(clusterName, suffix string) (*clusterv1.ManagedCluster
 		return nil, err
 	}
 
-	// This test expects a bootstrap secret to exist in open-cluster-management/e2e-bootstrap-secret
-	e2eBootstrapSecret, err := hubClient.CoreV1().Secrets("open-cluster-management").Get(context.TODO(), "e2e-bootstrap-secret", metav1.GetOptions{})
+	// This test expects a bootstrap secret to exist in open-cluster-management-agent/e2e-bootstrap-secret
+	e2eBootstrapSecret, err := hubClient.CoreV1().Secrets("open-cluster-management-agent").Get(context.TODO(), "e2e-bootstrap-secret", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/loopback_test.go
+++ b/test/e2e/loopback_test.go
@@ -113,8 +113,8 @@ var _ = ginkgo.Describe("Loopback registration [development]", func() {
 		})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-		// This test expects a bootstrap secret to exist in open-cluster-management/e2e-bootstrap-secret
-		e2eBootstrapSecret, err := hubClient.CoreV1().Secrets("open-cluster-management").Get(context.TODO(), "e2e-bootstrap-secret", metav1.GetOptions{})
+		// This test expects a bootstrap secret to exist in open-cluster-management-agent/e2e-bootstrap-secret
+		e2eBootstrapSecret, err := hubClient.CoreV1().Secrets("open-cluster-management-agent").Get(context.TODO(), "e2e-bootstrap-secret", metav1.GetOptions{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 		bootstrapSecret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -136,7 +136,7 @@ var _ = ginkgo.BeforeSuite(func(done ginkgo.Done) {
 	// prepare test namespace
 	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
-		testNamespace = "open-cluster-management"
+		testNamespace = "open-cluster-management-agent"
 	} else {
 		testNamespace = string(nsBytes)
 	}


### PR DESCRIPTION
This PR supports deploying registration control plane and agent in two separate clusters and in different namespaces. It is good for new guys to understand the registration.

Signed-off-by: zhujian <jiazhu@redhat.com>

cc @qiujian16 @skeeey 