### PR TITLE
add controller to set default clusterset label

### DIFF
--- a/pkg/hub/managedclusterset/default_managedclusterset_label_controller.go
+++ b/pkg/hub/managedclusterset/default_managedclusterset_label_controller.go
@@ -1,0 +1,106 @@
+package managedclusterset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	clientset "open-cluster-management.io/api/client/cluster/clientset/versioned"
+	clusterinformerv1 "open-cluster-management.io/api/client/cluster/informers/externalversions/cluster/v1"
+	clusterlisterv1 "open-cluster-management.io/api/client/cluster/listers/cluster/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+const (
+	defaultManagedClusterSetValue = "default"
+)
+
+// defaultManagedClusterSetLabelController is used to add a "default" clusterset label to managedcluster
+// to add it to default managed cluster set if it it not belongs to any cluster set and have no cluster
+// set label.
+// This controller would be removed in next release.
+//
+// defaultManagedClusterSetLabelController reconciles ManagedClusterSet label.
+type defaultManagedClusterSetLabelController struct {
+	clusterClient clientset.Interface
+	clusterLister clusterlisterv1.ManagedClusterLister
+	eventRecorder events.Recorder
+}
+
+// NewDefaultManagedClusterSetLabelController creates a new set ManagedClusterSet label controller
+func NewDefaultManagedClusterSetLabelController(
+	clusterClient clientset.Interface,
+	clusterInformer clusterinformerv1.ManagedClusterInformer,
+	recorder events.Recorder) factory.Controller {
+
+	c := &defaultManagedClusterSetLabelController{
+		clusterClient: clusterClient,
+		clusterLister: clusterInformer.Lister(),
+		eventRecorder: recorder.WithComponentSuffix("set-default-managed-cluster-set-label-controller"),
+	}
+
+	return factory.New().
+		WithInformersQueueKeyFunc(func(obj runtime.Object) string {
+			accessor, _ := meta.Accessor(obj)
+			return accessor.GetName()
+		}, clusterInformer.Informer()).
+		WithSync(c.sync).
+		ToController("DefaultManagedClusterSetLabelController", recorder)
+}
+
+func (c *defaultManagedClusterSetLabelController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	managedClusterName := syncCtx.QueueKey()
+
+	klog.V(4).Infof("Reconciling ManagedClusterSetLabel of ManagedCluster %s", managedClusterName)
+
+	managedCluster, err := c.clusterLister.Get(managedClusterName)
+	if errors.IsNotFound(err) {
+		// Spoke cluster not found, could have been deleted, do nothing.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !managedCluster.DeletionTimestamp.IsZero() {
+		// ManagedCluster is deleting, do nothing
+		return nil
+	}
+
+	if err := c.syncClusterSetLabel(ctx, managedCluster); err != nil {
+		return fmt.Errorf("failed to set default ManagedClusterSet label to ManagedCluster %s: %w", managedCluster.Name, err)
+	}
+	return nil
+}
+
+func (c *defaultManagedClusterSetLabelController) syncClusterSetLabel(ctx context.Context, managedCluster *clusterv1.ManagedCluster) error {
+	cluster := managedCluster.DeepCopy()
+
+	if v, ok := cluster.Labels[clusterSetLabel]; !ok || v == "" {
+		modified := false
+
+		clusterSetLabels := map[string]string{}
+		clusterSetLabels[clusterSetLabel] = defaultManagedClusterSetValue
+		// merge clusterSetLabel into ManagedCluster.Labels
+		resourcemerge.MergeMap(&modified, &cluster.Labels, clusterSetLabels)
+
+		// no work if the cluster labels have no change
+		if !modified {
+			return nil
+		}
+
+		// update ManagedCluster Labels
+		_, err := c.clusterClient.ClusterV1().ManagedClusters().Update(ctx, cluster, metav1.UpdateOptions{})
+		return err
+	}
+
+	// if clusterSetLabel already set, do nothing
+	return nil
+}

--- a/pkg/hub/managedclusterset/default_managedclusterset_label_controller_test.go
+++ b/pkg/hub/managedclusterset/default_managedclusterset_label_controller_test.go
@@ -1,0 +1,124 @@
+package managedclusterset
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+	clusterfake "open-cluster-management.io/api/client/cluster/clientset/versioned/fake"
+	clusterinformers "open-cluster-management.io/api/client/cluster/informers/externalversions"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	testinghelpers "open-cluster-management.io/registration/pkg/helpers/testing"
+)
+
+func TestSyncClusterSetLabel(t *testing.T) {
+	cases := []struct {
+		name             string
+		existingClusters []*clusterv1.ManagedCluster
+		validateActions  func(t *testing.T, actions []clienttesting.Action)
+	}{
+		{
+			name:             "sync a deleted cluster",
+			existingClusters: []*clusterv1.ManagedCluster{},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testinghelpers.AssertNoActions(t, actions)
+			},
+		},
+		{
+			name: "sync a deleting cluster",
+			existingClusters: []*clusterv1.ManagedCluster{
+				newCluster(testinghelpers.TestManagedClusterName, true),
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testinghelpers.AssertNoActions(t, actions)
+			},
+		},
+		{
+			name: "sync a labeled cluster",
+			existingClusters: []*clusterv1.ManagedCluster{
+				newClusterWithLabel(testinghelpers.TestManagedClusterName, clusterSetLabel, defaultManagedClusterSetValue),
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testinghelpers.AssertNoActions(t, actions)
+			},
+		},
+		{
+			name: "sync a cluster",
+			existingClusters: []*clusterv1.ManagedCluster{
+				newCluster(testinghelpers.TestManagedClusterName, false),
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testinghelpers.AssertActions(t, actions, "update")
+				cluster := actions[0].(clienttesting.UpdateAction).GetObject().(*clusterv1.ManagedCluster)
+				if !hasLabel(cluster, clusterSetLabel, defaultManagedClusterSetValue) {
+					t.Errorf("expected label %v:%v is not found", clusterSetLabel, defaultManagedClusterSetValue)
+				}
+
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			objects := []runtime.Object{}
+			for _, cluster := range c.existingClusters {
+				objects = append(objects, cluster)
+			}
+
+			clusterClient := clusterfake.NewSimpleClientset(objects...)
+			informerFactory := clusterinformers.NewSharedInformerFactory(clusterClient, 5*time.Minute)
+			for _, cluster := range c.existingClusters {
+				informerFactory.Cluster().V1().ManagedClusters().Informer().GetStore().Add(cluster)
+			}
+
+			ctrl := defaultManagedClusterSetLabelController{
+				clusterClient: clusterClient,
+				clusterLister: informerFactory.Cluster().V1().ManagedClusters().Lister(),
+				eventRecorder: eventstesting.NewTestingEventRecorder(t),
+			}
+
+			syncErr := ctrl.sync(context.Background(), testinghelpers.NewFakeSyncContext(t, testinghelpers.TestManagedClusterName))
+			if syncErr != nil {
+				t.Errorf("unexpected err: %v", syncErr)
+			}
+
+			c.validateActions(t, clusterClient.Actions())
+
+		})
+	}
+}
+
+func newCluster(name string, terminating bool) *clusterv1.ManagedCluster {
+	cluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if terminating {
+		now := metav1.Now()
+		cluster.DeletionTimestamp = &now
+	}
+
+	return cluster
+}
+
+func newClusterWithLabel(name string, labelKey string, labelValue string) *clusterv1.ManagedCluster {
+	cluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				labelKey: labelValue,
+			},
+		},
+	}
+	return cluster
+}
+
+func hasLabel(mcl *clusterv1.ManagedCluster, key string, value string) bool {
+	v, ok := mcl.Labels[key]
+	return ok && (v == value)
+}

--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -133,11 +133,17 @@ func RunControllerManager(ctx context.Context, controllerContext *controllercmd.
 		controllerContext.EventRecorder,
 	)
 
-	var defaultManagedClusterSetController factory.Controller
+	var defaultManagedClusterSetController, defaultManagedClusterSetLabelController factory.Controller
 	if features.DefaultHubMutableFeatureGate.Enabled(features.DefaultClusterSet) {
 		defaultManagedClusterSetController = managedclusterset.NewDefaultManagedClusterSetController(
 			clusterClient.ClusterV1beta1(),
 			clusterInformers.Cluster().V1beta1().ManagedClusterSets(),
+			controllerContext.EventRecorder,
+		)
+
+		defaultManagedClusterSetLabelController = managedclusterset.NewDefaultManagedClusterSetLabelController(
+			clusterClient,
+			clusterInformers.Cluster().V1().ManagedClusters(),
 			controllerContext.EventRecorder,
 		)
 	}
@@ -158,6 +164,7 @@ func RunControllerManager(ctx context.Context, controllerContext *controllercmd.
 	go addOnFeatureDiscoveryController.Run(ctx, 1)
 	if features.DefaultHubMutableFeatureGate.Enabled(features.DefaultClusterSet) {
 		go defaultManagedClusterSetController.Run(ctx, 1)
+		go defaultManagedClusterSetLabelController.Run(ctx, 1)
 	}
 
 	<-ctx.Done()

--- a/test/integration/default_managedclusterset_label_controller_test.go
+++ b/test/integration/default_managedclusterset_label_controller_test.go
@@ -1,0 +1,111 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+const (
+	defaultManagedClusterSetValue = "default"
+)
+
+var _ = ginkgo.Describe("DefaultManagedClusterSetLabel", func() {
+	ginkgo.It("should ensure managed cluster has a cluster set label", func() {
+		ginkgo.By("Create a ManagedCluster with no label")
+		mcl1, err := newManagedCluster()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "create managed cluster failed")
+
+		ginkgo.By("Check whether DefaultManagedClusterSetLabel is set")
+		gomega.Eventually(func() bool {
+			cluster1, err := clusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), mcl1.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			if hasLabel(cluster1, clusterSetLabel, defaultManagedClusterSetValue) {
+				return true
+			}
+			return false
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+	})
+
+	ginkgo.It("should ensure managed cluster label is not \"\"", func() {
+		ginkgo.By("Create a ManagedCluster with empty-valued label")
+		mcl2, err := newManagedClusterWithLabel(clusterSetLabel, "")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "create managed cluster failed")
+
+		ginkgo.By("Check whether DefaultManagedClusterSetLabel value is empty")
+		gomega.Eventually(func() bool {
+			cluster2, err := clusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), mcl2.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			if hasLabel(cluster2, clusterSetLabel, defaultManagedClusterSetValue) {
+				return true
+			}
+			return false
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+	})
+
+	ginkgo.It("should ensure managed cluster label is default", func() {
+		ginkgo.By("Create a ManagedCluster with default label")
+		mcl2, err := newManagedClusterWithLabel(clusterSetLabel, defaultManagedClusterSetValue)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "create managed cluster failed")
+
+		ginkgo.By("Check whether DefaultManagedClusterSetLabel value is default")
+		gomega.Eventually(func() bool {
+			cluster2, err := clusterClient.ClusterV1().ManagedClusters().Get(context.TODO(), mcl2.Name, metav1.GetOptions{})
+			if err != nil {
+				return false
+			}
+			if hasLabel(cluster2, clusterSetLabel, defaultManagedClusterSetValue) {
+				return true
+			}
+			return false
+		}, eventuallyTimeout, eventuallyInterval).Should(gomega.BeTrue())
+
+	})
+})
+
+func newManagedCluster() (*clusterv1.ManagedCluster, error) {
+	managedClusterName := fmt.Sprintf("managedcluster-%s", rand.String(6))
+	managedCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: managedClusterName,
+		},
+		Spec: clusterv1.ManagedClusterSpec{
+			HubAcceptsClient: true,
+		},
+	}
+
+	return clusterClient.ClusterV1().ManagedClusters().Create(context.Background(), managedCluster, metav1.CreateOptions{})
+}
+
+func newManagedClusterWithLabel(key, value string) (*clusterv1.ManagedCluster, error) {
+	managedClusterName := fmt.Sprintf("managedcluster-%s", rand.String(6))
+	managedCluster := &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: managedClusterName,
+			Labels: map[string]string{
+				key: value,
+			},
+		},
+		Spec: clusterv1.ManagedClusterSpec{
+			HubAcceptsClient: true,
+		},
+	}
+
+	return clusterClient.ClusterV1().ManagedClusters().Create(context.Background(), managedCluster, metav1.CreateOptions{})
+}
+
+func hasLabel(mcl *clusterv1.ManagedCluster, key, value string) bool {
+	v, ok := mcl.Labels[key]
+	return ok && v == value
+}


### PR DESCRIPTION
add a controller to set default cluster set label for managed clusters which not set cluster set label.
the label will be `cluster.open-cluster-management.io/clusterset:default`

Signed-off-by: ycyaoxdu <yaoyuchen0626@163.com>