### PR TITLE
update clusterset contoller to ignore non-legacy clusterset

### DIFF
--- a/pkg/hub/managedclusterset/controller.go
+++ b/pkg/hub/managedclusterset/controller.go
@@ -141,8 +141,15 @@ func (c *managedClusterSetController) sync(ctx context.Context, syncCtx factory.
 	return nil
 }
 
-// syncClusterSet syncs a particular cluster set
+// syncClusterSet syncs a particular cluster set. Currently only support the legacy type of clusterset.
+// The logic should be updated once any new type of clusterset added.
 func (c *managedClusterSetController) syncClusterSet(ctx context.Context, originalClusterSet *clusterv1beta1.ManagedClusterSet) error {
+	// ignore the non-legacy clusterset
+	selectorType := originalClusterSet.Spec.ClusterSelector.SelectorType
+	if len(selectorType) > 0 && selectorType != clusterv1beta1.LegacyClusterSetLabel {
+		return nil
+	}
+
 	clusterSet := originalClusterSet.DeepCopy()
 
 	// find out the containing clusters of clusterset

--- a/pkg/hub/managedclusterset/controller_test.go
+++ b/pkg/hub/managedclusterset/controller_test.go
@@ -84,6 +84,40 @@ func TestSyncClusterSet(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:           "sync a legacy clusterset",
+			clusterSetName: "mcs1",
+			existingClusterSet: &clusterv1beta1.ManagedClusterSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mcs1",
+				},
+				Spec: clusterv1beta1.ManagedClusterSetSpec{
+					ClusterSelector: clusterv1beta1.ManagedClusterSelector{
+						SelectorType: clusterv1beta1.LegacyClusterSetLabel,
+					},
+				},
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testinghelpers.AssertActions(t, actions, "update")
+			},
+		},
+		{
+			name:           "ignore any non-legacy clusterset",
+			clusterSetName: "mcs1",
+			existingClusterSet: &clusterv1beta1.ManagedClusterSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mcs1",
+				},
+				Spec: clusterv1beta1.ManagedClusterSetSpec{
+					ClusterSelector: clusterv1beta1.ManagedClusterSelector{
+						SelectorType: "SingleClusterLabel",
+					},
+				},
+			},
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testinghelpers.AssertNoActions(t, actions)
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Related task: https://github.com/stolostron/backlog/issues/20209
Signed-off-by: Yang Le <yangle@redhat.com>