### PR TITLE
add disable annotation detection for default managed cluster set

### DIFF
--- a/pkg/hub/managedclusterset/default_managedclusterset_controller_test.go
+++ b/pkg/hub/managedclusterset/default_managedclusterset_controller_test.go
@@ -67,6 +67,13 @@ func TestSyncDefaultClusterSet(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:               "sync default cluster set with disabled annotation",
+			existingClusterSet: newDefaultManagedClusterSetWithAnnotation(defaultManagedClusterSetName, autoUpdateAnnotation, "false", defaultManagedClusterSetSpec, false),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				testinghelpers.AssertNoActions(t, actions)
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -105,6 +112,24 @@ func newDefaultManagedClusterSet(name string, spec clusterv1beta1.ManagedCluster
 	clusterSet := &clusterv1beta1.ManagedClusterSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+		},
+		Spec: spec,
+	}
+	if terminating {
+		now := metav1.Now()
+		clusterSet.DeletionTimestamp = &now
+	}
+
+	return clusterSet
+}
+
+func newDefaultManagedClusterSetWithAnnotation(name string, k, v string, spec clusterv1beta1.ManagedClusterSetSpec, terminating bool) *clusterv1beta1.ManagedClusterSet {
+	clusterSet := &clusterv1beta1.ManagedClusterSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				k: v,
+			},
 		},
 		Spec: spec,
 	}

--- a/test/integration/default_managedclusterset_controller_test.go
+++ b/test/integration/default_managedclusterset_controller_test.go
@@ -60,4 +60,6 @@ var _ = ginkgo.Describe("DefaultManagedClusterSet", func() {
 		}, eventuallyTimeout, eventuallyInterval).ShouldNot(gomega.HaveOccurred())
 	})
 
+	// TODO:
+	//		add test case for edit default managedclusterset spec operation
 })


### PR DESCRIPTION
add disable annotation detection for default managed cluster set, ensuring users have property to modify default managed cluster set spec

Signed-off-by: ycyaoxdu <yaoyuchen0626@163.com>