### PR TITLE
begin to remove resources on Hub when there is only api-resource-cleanup finalizer

### DIFF
--- a/pkg/hub/managedcluster/controller.go
+++ b/pkg/hub/managedcluster/controller.go
@@ -98,8 +98,13 @@ func (c *managedClusterController) sync(ctx context.Context, syncCtx factory.Syn
 		}
 	}
 
-	// Spoke cluster is deleting, we remove its related resources
+	// Spoke cluster is deleting, we remove its related resources until there is only api-resource-cleanup finalizer
+	// or no finalizer.
 	if !managedCluster.DeletionTimestamp.IsZero() {
+		if len(managedCluster.Finalizers) > 1 {
+			return nil
+		}
+
 		if err := c.removeManagedClusterResources(ctx, managedClusterName); err != nil {
 			return err
 		}


### PR DESCRIPTION

when the mcl is deleting, the addon with pre-delete needs to deploy pre-delete manifestWork on the cluster to do some cleanup job.
in this case, we should begin to remove resources until all of finalizers expect api-resource-cleanup are removed .

Signed-off-by: Zhiwei Yin <zyin@redhat.com>