### PR TITLE
update serverURL and CABundle if ManagedCluster is created before reg…

### DIFF
--- a/pkg/spoke/managedcluster/creating_controller.go
+++ b/pkg/spoke/managedcluster/creating_controller.go
@@ -54,7 +54,7 @@ func NewManagedClusterCreatingController(
 
 func (c *managedClusterCreatingController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	existingCluster, err := c.hubClusterClient.ClusterV1().ManagedClusters().Get(ctx, c.clusterName, metav1.GetOptions{})
-	if err != nil && (errors.IsUnauthorized(err) || errors.IsForbidden(err) && strings.Contains(err.Error(), anonymous)) {
+	if err != nil && skipUnauthorizedError(err) == nil && strings.Contains(err.Error(), anonymous) {
 		klog.V(4).Infof("unable to get the managed cluster %q from hub: %v", c.clusterName, err)
 		return nil
 	}
@@ -64,7 +64,7 @@ func (c *managedClusterCreatingController) sync(ctx context.Context, syncCtx fac
 	}
 
 	// create ManagedCluster if not found
-	if err != nil && errors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		managedCluster := &clusterv1.ManagedCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: c.clusterName,

--- a/pkg/spoke/managedcluster/creating_controller.go
+++ b/pkg/spoke/managedcluster/creating_controller.go
@@ -53,47 +53,80 @@ func NewManagedClusterCreatingController(
 }
 
 func (c *managedClusterCreatingController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
-	var managedClusterClientConfigs []clusterv1.ClientConfig
-	if len(c.spokeExternalServerURLs) != 0 {
-		for _, serverURL := range c.spokeExternalServerURLs {
+	existingCluster, err := c.hubClusterClient.ClusterV1().ManagedClusters().Get(ctx, c.clusterName, metav1.GetOptions{})
+	if err != nil && (errors.IsUnauthorized(err) || errors.IsForbidden(err) && strings.Contains(err.Error(), anonymous)) {
+		klog.V(4).Infof("unable to get the managed cluster %q from hub: %v", c.clusterName, err)
+		return nil
+	}
+
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	// create ManagedCluster if not found
+	if err != nil && errors.IsNotFound(err) {
+		managedCluster := &clusterv1.ManagedCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: c.clusterName,
+			},
+		}
+
+		if len(c.spokeExternalServerURLs) != 0 {
+			var managedClusterClientConfigs []clusterv1.ClientConfig
+			for _, serverURL := range c.spokeExternalServerURLs {
+				managedClusterClientConfigs = append(managedClusterClientConfigs, clusterv1.ClientConfig{
+					URL:      serverURL,
+					CABundle: c.spokeCABundle,
+				})
+			}
+			managedCluster.Spec.ManagedClusterClientConfigs = managedClusterClientConfigs
+		}
+
+		_, err = c.hubClusterClient.ClusterV1().ManagedClusters().Create(ctx, managedCluster, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to create managed cluster with name %q on hub: %w", c.clusterName, err)
+		}
+		syncCtx.Recorder().Eventf("ManagedClusterCreated", "Managed cluster %q created on hub", c.clusterName)
+		return nil
+	}
+
+	// do not update ManagedClusterClientConfigs in ManagedCluster if spokeExternalServerURLs is empty
+	if len(c.spokeExternalServerURLs) == 0 {
+		return nil
+	}
+
+	// merge ClientConfig
+	managedClusterClientConfigs := existingCluster.Spec.ManagedClusterClientConfigs
+	for _, serverURL := range c.spokeExternalServerURLs {
+		isIncludeByExisting := false
+		for _, existingClientConfig := range existingCluster.Spec.ManagedClusterClientConfigs {
+			if serverURL == existingClientConfig.URL {
+				isIncludeByExisting = true
+				break
+			}
+		}
+
+		if !isIncludeByExisting {
 			managedClusterClientConfigs = append(managedClusterClientConfigs, clusterv1.ClientConfig{
 				URL:      serverURL,
 				CABundle: c.spokeCABundle,
 			})
 		}
 	}
-
-	existingCluster, err := c.hubClusterClient.ClusterV1().ManagedClusters().Get(ctx, c.clusterName, metav1.GetOptions{})
-	switch {
-	case errors.IsUnauthorized(err),
-		errors.IsForbidden(err) && strings.Contains(err.Error(), anonymous):
-		klog.V(4).Infof("unable to get the managed cluster %q from hub: %v", c.clusterName, err)
+	if len(existingCluster.Spec.ManagedClusterClientConfigs) == len(managedClusterClientConfigs) {
 		return nil
-	case errors.IsNotFound(err):
-	case err == nil:
-		if len(existingCluster.Spec.ManagedClusterClientConfigs) == 0 && len(managedClusterClientConfigs) > 0 {
-			clusterCopy := existingCluster.DeepCopy()
-			clusterCopy.Spec.ManagedClusterClientConfigs = managedClusterClientConfigs
-			if _, err := c.hubClusterClient.ClusterV1().ManagedClusters().Update(ctx, clusterCopy, metav1.UpdateOptions{}); err != nil {
-				return fmt.Errorf("unable to update ManagedClusterClientConfigs of managed cluster %q on hub: %w", c.clusterName, err)
-			}
+	}
+
+	// update ManagedClusterClientConfigs in ManagedCluster
+	clusterCopy := existingCluster.DeepCopy()
+	clusterCopy.Spec.ManagedClusterClientConfigs = managedClusterClientConfigs
+	if _, err := c.hubClusterClient.ClusterV1().ManagedClusters().Update(ctx, clusterCopy, metav1.UpdateOptions{}); err != nil {
+		if errors.IsUnauthorized(err) || errors.IsForbidden(err) && strings.Contains(err.Error(), anonymous) {
+			klog.V(4).Infof("unable to update the managed cluster %q in hub: %v", c.clusterName, err)
+			return nil
 		}
-		return nil
-	case err != nil:
-		return err
+		return fmt.Errorf("unable to update ManagedClusterClientConfigs of managed cluster %q in hub: %w", c.clusterName, err)
 	}
 
-	managedCluster := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: c.clusterName,
-		},
-	}
-	managedCluster.Spec.ManagedClusterClientConfigs = managedClusterClientConfigs
-
-	_, err = c.hubClusterClient.ClusterV1().ManagedClusters().Create(ctx, managedCluster, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to create managed cluster with name %q on hub: %w", c.clusterName, err)
-	}
-	syncCtx.Recorder().Eventf("ManagedClusterCreated", "Managed cluster %q created on hub", c.clusterName)
 	return nil
 }

--- a/pkg/spoke/managedcluster/creating_controller_test.go
+++ b/pkg/spoke/managedcluster/creating_controller_test.go
@@ -40,7 +40,7 @@ func TestCreateSpokeCluster(t *testing.T) {
 			name:            "create an existed cluster",
 			startingObjects: []runtime.Object{testinghelpers.NewManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testinghelpers.AssertActions(t, actions, "get")
+				testinghelpers.AssertActions(t, actions, "get", "update")
 			},
 		},
 	}


### PR DESCRIPTION
…istration-agent running

Sometimes, ManagedCluster is created before deploy klusterlet, we want registration-agent can also update serverURL and CABundle from Klusterlet CR while it is running.

[cluster-gateway](https://github.com/oam-dev/cluster-gateway) will use  serverURL and CABundle in ManagedCluster if ClusterEndpointType is `Const` not `ClusterProxy`.

Signed-off-by: ivan-cai <caijing.cai@alibaba-inc.com>