### PR TITLE
fix cluster labels update conflict.

### DIFF
--- a/pkg/hub/addon/discovery_controller_test.go
+++ b/pkg/hub/addon/discovery_controller_test.go
@@ -387,44 +387,27 @@ func TestDiscoveryController_Sync(t *testing.T) {
 }
 
 func assertPatchAddonLabel(t *testing.T, actionPatch clienttesting.PatchActionImpl, addOnName, addOnStatus string) {
-	var patchObj map[string]map[string]map[string]string
-	if err := json.Unmarshal(actionPatch.Patch, &patchObj); err != nil {
-		t.Errorf("failed to unmarshal patch %s: %v", patchObj, err)
+	var patchClusterObj clusterv1.ManagedCluster
+	if err := json.Unmarshal(actionPatch.Patch, &patchClusterObj); err != nil {
+		t.Errorf("failed to unmarshal patch %s: %v", actionPatch.Patch, err)
 	}
-	metadata, ok := patchObj["metadata"]
-	if !ok {
-		t.Errorf("patch %s doesn't contain metadata field", patchObj)
-	}
-	labels, ok := metadata["labels"]
-	if !ok {
-		t.Errorf("patch %s doesn't contain metadata.labels field", patchObj)
-	}
-
+	labels := patchClusterObj.Labels
 	key := fmt.Sprintf("%s%s", addOnFeaturePrefix, addOnName)
 	value, ok := labels[key]
 	if !ok {
 		t.Errorf("label %q not found", key)
 	}
-
 	if value != addOnStatus {
 		t.Errorf("expect label value %q but found %q", addOnStatus, value)
 	}
 }
 
 func assertPatchNoAddonLabel(t *testing.T, actionPatch clienttesting.PatchActionImpl, addOnName string) {
-	var patchObj map[string]map[string]map[string]string
-	if err := json.Unmarshal(actionPatch.Patch, &patchObj); err != nil {
-		t.Errorf("failed to unmarshal patch %s: %v", patchObj, err)
+	var patchClusterObj clusterv1.ManagedCluster
+	if err := json.Unmarshal(actionPatch.Patch, &patchClusterObj); err != nil {
+		t.Errorf("failed to unmarshal patch %s: %v", actionPatch.Patch, err)
 	}
-	metadata, ok := patchObj["metadata"]
-	if !ok {
-		t.Errorf("patch %s doesn't contain metadata field", patchObj)
-	}
-	labels, ok := metadata["labels"]
-	if !ok {
-		t.Errorf("patch %s doesn't contain metadata.labels field", patchObj)
-	}
-
+	labels := patchClusterObj.Labels
 	key := fmt.Sprintf("%s%s", addOnFeaturePrefix, addOnName)
 	if _, ok := labels[key]; ok {
 		t.Errorf("label %q found", key)

--- a/pkg/hub/taint/controller.go
+++ b/pkg/hub/taint/controller.go
@@ -96,6 +96,10 @@ func (c *taintController) sync(ctx context.Context, syncCtx factory.SyncContext)
 		}
 		// build cluster taints patch
 		patchBytes, err := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"uid":             managedCluster.UID,
+				"resourceVersion": managedCluster.ResourceVersion,
+			}, // to ensure they appear in the patch as preconditions
 			"spec": map[string]interface{}{
 				"taints": newTaints,
 			},

--- a/pkg/hub/taint/controller.go
+++ b/pkg/hub/taint/controller.go
@@ -90,6 +90,10 @@ func (c *taintController) sync(ctx context.Context, syncCtx factory.SyncContext)
 	}
 
 	if updated {
+		// for empty newTaints, assign it to nil, otherwise patch operation will take no effect
+		if len(newTaints) == 0 {
+			newTaints = nil
+		}
 		// build cluster taints patch
 		patchBytes, err := json.Marshal(map[string]interface{}{
 			"spec": map[string]interface{}{

--- a/pkg/hub/taint/controller_test.go
+++ b/pkg/hub/taint/controller_test.go
@@ -2,6 +2,7 @@ package taint
 
 import (
 	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -35,11 +36,15 @@ func TestSyncTaintCluster(t *testing.T) {
 			name:            "ManagedClusterConditionAvailable conditionStatus is False",
 			startingObjects: []runtime.Object{testinghelpers.NewUnAvailableManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testinghelpers.AssertActions(t, actions, "update")
-				managedCluster := (actions[0].(clienttesting.UpdateActionImpl).Object).(*v1.ManagedCluster)
+				testinghelpers.AssertActions(t, actions, "patch")
+				actualPatchAction := actions[0].(clienttesting.PatchActionImpl)
+				var managedClusterPatch v1.ManagedCluster
+				if err := json.Unmarshal(actualPatchAction.Patch, &managedClusterPatch); err != nil {
+					t.Errorf("failed to unmarshal patch %s: %v", actualPatchAction.Patch, err)
+				}
 				taints := []v1.Taint{UnavailableTaint}
-				if !reflect.DeepEqual(managedCluster.Spec.Taints, taints) {
-					t.Errorf("expected taint %#v, but actualTaints: %#v", taints, managedCluster.Spec.Taints)
+				if !reflect.DeepEqual(managedClusterPatch.Spec.Taints, taints) {
+					t.Errorf("expected taint %#v, but actualTaints: %#v", taints, managedClusterPatch.Spec.Taints)
 				}
 			},
 		},
@@ -47,11 +52,15 @@ func TestSyncTaintCluster(t *testing.T) {
 			name:            "There is no ManagedClusterConditionAvailable",
 			startingObjects: []runtime.Object{testinghelpers.NewManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testinghelpers.AssertActions(t, actions, "update")
-				managedCluster := (actions[0].(clienttesting.UpdateActionImpl).Object).(*v1.ManagedCluster)
+				testinghelpers.AssertActions(t, actions, "patch")
+				actualPatchAction := actions[0].(clienttesting.PatchActionImpl)
+				var managedClusterPatch v1.ManagedCluster
+				if err := json.Unmarshal(actualPatchAction.Patch, &managedClusterPatch); err != nil {
+					t.Errorf("failed to unmarshal patch %s: %v", actualPatchAction.Patch, err)
+				}
 				taints := []v1.Taint{UnreachableTaint}
-				if !reflect.DeepEqual(managedCluster.Spec.Taints, taints) {
-					t.Errorf("expected taint %#v, but actualTaints: %#v", taints, managedCluster.Spec.Taints)
+				if !reflect.DeepEqual(managedClusterPatch.Spec.Taints, taints) {
+					t.Errorf("expected taint %#v, but actualTaints: %#v", taints, managedClusterPatch.Spec.Taints)
 				}
 			},
 		},
@@ -59,11 +68,15 @@ func TestSyncTaintCluster(t *testing.T) {
 			name:            "ManagedClusterConditionAvailable conditionStatus is Unknown",
 			startingObjects: []runtime.Object{testinghelpers.NewUnknownManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				testinghelpers.AssertActions(t, actions, "update")
-				managedCluster := (actions[0].(clienttesting.UpdateActionImpl).Object).(*v1.ManagedCluster)
+				testinghelpers.AssertActions(t, actions, "patch")
+				var managedClusterPatch v1.ManagedCluster
+				actualPatchAction := actions[0].(clienttesting.PatchActionImpl)
+				if err := json.Unmarshal(actualPatchAction.Patch, &managedClusterPatch); err != nil {
+					t.Errorf("failed to unmarshal patch %s: %v", actualPatchAction.Patch, err)
+				}
 				taints := []v1.Taint{UnreachableTaint}
-				if !reflect.DeepEqual(managedCluster.Spec.Taints, taints) {
-					t.Errorf("expected taint %#v, but actualTaints: %#v", taints, managedCluster.Spec.Taints)
+				if !reflect.DeepEqual(managedClusterPatch.Spec.Taints, taints) {
+					t.Errorf("expected taint %#v, but actualTaints: %#v", taints, managedClusterPatch.Spec.Taints)
 				}
 			},
 		},


### PR DESCRIPTION
fix cluster labels update conflict:

```
E1122 13:49:38.188870       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-4/work-manager", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-4": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.423603       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-3/governance-policy-framework", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-3": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.438568       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-1/config-policy-controller", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-1": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.451226       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-3/config-policy-controller", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-3": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.460923       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-1/config-policy-controller", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-1": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.477055       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-1/governance-policy-framework", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-1": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.488734       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-3", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-3": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.503787       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-1/governance-policy-framework", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-1": the object has been modified; please apply your changes to the latest version and try again
E1122 13:49:45.511774       1 base_controller.go:270] "AddOnFeatureDiscoveryController" controller failed to sync "ocm-controlplane-1-mc-3", err: Operation cannot be fulfilled on managedclusters.cluster.open-cluster-management.io "ocm-controlplane-1-mc-3": the object has been modified; please apply your changes to the latest version and try again
```

Signed-off-by: morvencao <lcao@redhat.com>