### PR TITLE
Fix code quaility issues report by gosec.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ verify-gocilint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 	golangci-lint run --timeout=3m --modules-download-mode vendor ./...
 
+verify-gosec:
+	go install github.com/securego/gosec/v2/cmd/gosec@v2.15.0
+	gosec -exclude-dir=testing -exclude-dir=test ./...
+
 update-crds:
 	bash -x hack/copy-crds.sh
 
@@ -47,7 +51,7 @@ update: update-crds
 verify-crds:
 	bash -x hack/verify-crds.sh
 
-verify: verify-crds verify-gocilint
+verify: verify-crds verify-gocilint verify-gosec
 
 deploy-hub: ensure-kustomize
 	cp deploy/hub/kustomization.yaml deploy/hub/kustomization.yaml.tmp
@@ -94,7 +98,7 @@ deploy-spoke: ensure-kustomize
 	$(KUBECTL) config use-context $(SPOKE_KUBECONFIG_CONTEXT) --kubeconfig $(SPOKE_KUBECONFIG)
 	$(KUSTOMIZE) build deploy/spoke | $(KUBECTL) --kubeconfig $(SPOKE_KUBECONFIG) apply -f -
 	mv deploy/spoke/kustomization.yaml.tmp deploy/spoke/kustomization.yaml
-	$(KUBECTL) --kubeconfig $(SPOKE_KUBECONFIG) apply -f deploy/spoke/role_extension-apiserver.yaml 
+	$(KUBECTL) --kubeconfig $(SPOKE_KUBECONFIG) apply -f deploy/spoke/role_extension-apiserver.yaml
 	$(KUBECTL) --kubeconfig $(SPOKE_KUBECONFIG) apply -f deploy/spoke/role_binding_extension-apiserver.yaml
 
 clean-hub:

--- a/pkg/clientcert/cert_controller.go
+++ b/pkg/clientcert/cert_controller.go
@@ -399,7 +399,7 @@ func jitter(percentage float64, maxFactor float64) float64 {
 	if maxFactor <= 0.0 {
 		maxFactor = 1.0
 	}
-	newPercentage := percentage + percentage*rand.Float64()*maxFactor
+	newPercentage := percentage + percentage*rand.Float64()*maxFactor //#nosec G404
 	return newPercentage
 }
 

--- a/pkg/spoke/managedcluster/secret_controller.go
+++ b/pkg/spoke/managedcluster/secret_controller.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -93,7 +94,7 @@ func DumpSecret(
 	// create/update files from the secret
 	for key, data := range secret.Data {
 		filename := path.Clean(path.Join(outputDir, key))
-		lastData, err := ioutil.ReadFile(filename)
+		lastData, err := ioutil.ReadFile(filepath.Clean(filename))
 		switch {
 		case os.IsNotExist(err):
 			// create file


### PR DESCRIPTION
Fixes issues report by [gosec](https://securego.io/) and also add it in CI process.

The [gosec](https://securego.io/) report:

```
Results:


[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/pkg/helpers/testing/testinghelpers.go:336] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
    335: func NewV1beta1CSR(holder CSRHolder) *certv1beta1.CertificateSigningRequest {
  > 336: 	insecureRand := rand.New(rand.NewSource(0))
    337: 	pk, err := ecdsa.GenerateKey(elliptic.P256(), insecureRand)



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/pkg/helpers/testing/testinghelpers.go:303] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
    302: func NewCSR(holder CSRHolder) *certv1.CertificateSigningRequest {
  > 303: 	insecureRand := rand.New(rand.NewSource(0))
    304: 	pk, err := ecdsa.GenerateKey(elliptic.P256(), insecureRand)



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/pkg/clientcert/cert_controller.go:402] - G404 (CWE-338): Use of weak random number generator (math/rand instead of crypto/rand) (Confidence: MEDIUM, Severity: HIGH)
    401: 	}
  > 402: 	newPercentage := percentage + percentage*rand.Float64()*maxFactor
    403: 	return newPercentage



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:60] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    59: func createKubeConfig(context string, securePort string, serverCertFile, certFile, keyFile string) (*clientcmdapi.Config, error) {
  > 60: 	caData, err := ioutil.ReadFile(serverCertFile)
    61: 	if err != nil {



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/pkg/spoke/managedcluster/secret_controller.go:96] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    95: 		filename := path.Clean(path.Join(outputDir, key))
  > 96: 		lastData, err := ioutil.ReadFile(filename)
    97: 		switch {



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/pkg/helpers/testing/assertion.go:244] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    243: func AssertFileContent(t *testing.T, filePath string, expectedContent []byte) {
  > 244: 	content, _ := ioutil.ReadFile(filePath)
    245: 	if !bytes.Equal(content, expectedContent) {



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:351] - G601 (CWE-118): Implicit memory aliasing in for loop. (Confidence: MEDIUM, Severity: MEDIUM)
    350: 	for _, csr := range csrList.Items {
  > 351: 		csrs = append(csrs, &csr)
    352: 	}



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:191] - G301 (CWE-276): Expect directory permissions to be 0750 or less (Confidence: HIGH, Severity: MEDIUM)
    190: 	if _, err := os.Stat(configDir); os.IsNotExist(err) {
  > 191: 		if err = os.MkdirAll(configDir, 0755); err != nil {
    192: 			return err



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:105] - G301 (CWE-276): Expect directory permissions to be 0750 or less (Confidence: HIGH, Severity: MEDIUM)
    104: 	if _, err := os.Stat(CertDir); os.IsNotExist(err) {
  > 105: 		if err = os.MkdirAll(CertDir, 0755); err != nil {
    106: 			return err



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:199] - G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
    198: 	}
  > 199: 	if err := ioutil.WriteFile(path.Join(configDir, "bootstrap.key"), keyData, 0644); err != nil {
    200: 		return err



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:196] - G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
    195: 
  > 196: 	if err := ioutil.WriteFile(path.Join(configDir, "bootstrap.crt"), certData, 0644); err != nil {
    197: 		return err



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:146] - G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
    145: 	}
  > 146: 	if err := ioutil.WriteFile(t.caKeyFile, caKeyBuffer.Bytes(), 0644); err != nil {
    147: 		return err



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/test/integration/util/util.go:137] - G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
    136: 	}
  > 137: 	if err := ioutil.WriteFile(t.caFile, caCertBuffer.Bytes(), 0644); err != nil {
    138: 		return err



[/Users/xuezhao/go/src/github.com/xuezhaojun/registration/pkg/helpers/testing/testinghelpers.go:525] - G306 (CWE-276): Expect WriteFile permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
    524: func WriteFile(filename string, data []byte) {
  > 525: 	if err := ioutil.WriteFile(filename, data, 0644); err != nil {
    526: 		panic(err)



Summary:
  Gosec  : 2.15.0
  Files  : 65
  Lines  : 9425
  Nosec  : 0
  Issues : 14


```