### PR TITLE
not delete addon hub-kubeocnfig during addon is deleting

### DIFF
--- a/pkg/spoke/addon/registration_controller.go
+++ b/pkg/spoke/addon/registration_controller.go
@@ -143,9 +143,10 @@ func (c *addOnRegistrationController) syncAddOn(ctx context.Context, syncCtx fac
 		return err
 	}
 
-	// addon is deleting
+	// do not clean up during addon is deleting.
+	// in some case the addon agent may need hub-kubeconfig to do cleanup during deleting.
 	if !addOn.DeletionTimestamp.IsZero() {
-		return c.cleanup(ctx, addOnName)
+		return nil
 	}
 
 	cachedConfigs := c.addOnRegistrationConfigs[addOnName]


### PR DESCRIPTION
in some case, the addon agent needs hub-kubeconfig secret to do some cleanup works during the addon is deleting .so delete it after addon is deleted.